### PR TITLE
#33, Upgrade Scrapy to 1.6 so to run it on python 3.7. 

### DIFF
--- a/crawler/crawler/general_settings.py
+++ b/crawler/crawler/general_settings.py
@@ -12,6 +12,10 @@ django.setup()
 BOT_NAME = 'tw-rental-house-data'
 FEED_FORAMT = 'jsonlines'
 
+# For Python 3.7 compatibility
+# Ref: https://stackoverflow.com/questions/51522281/telnetconsole-enabled-setting-is-true-but-required-twisted-modules-failed-to-imp
+TELNETCONSOLE_ENABLED=False
+
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,8 @@ jsonfield==2.0.2
 lazy-object-proxy==1.3.1
 lxml==4.2.0
 mccabe==0.6.1
-parsel==1.4.0
+parsel==1.5.2
+pkg-resources==0.0.0
 psycopg2-binary==2.7.5
 pyasn1==0.4.2
 pyasn1-modules==0.2.1
@@ -29,7 +30,7 @@ pyOpenSSL==17.5.0
 pytz==2018.5
 queuelib==1.5.0
 raven==6.9.0
-Scrapy==1.5.0
+Scrapy==1.6.0
 service-identity==17.0.0
 six==1.11.0
 Twisted==17.9.0


### PR DESCRIPTION
FIXME: update Pipfile...  Fail to create Pipfile.lock as `pipenv update` timeout...