### PR TITLE
remove pkg-resources==0.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ lazy-object-proxy==1.3.1
 lxml==4.2.0
 mccabe==0.6.1
 parsel==1.5.2
-pkg-resources==0.0.0
 psycopg2-binary==2.7.5
 pyasn1==0.4.2
 pyasn1-modules==0.2.1


### PR DESCRIPTION
pkg-resources==0.0.0 is created due to a bug
resulting from Ubuntu providing incorrect metadata to pip

Ref:
1. reported bug
    https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463
2. discussion
    https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command/40167445#40167445