### PR TITLE
build(pyproject.toml): fix error repository link

### DIFF
--- a/scrapy-tw-rental-house/pyproject.toml
+++ b/scrapy-tw-rental-house/pyproject.toml
@@ -5,7 +5,7 @@ description = "Scrapy spider for TW Rental House"
 readme = "README.md"
 authors = ["ddio <ddio@ddio.io>"]
 license = "MIT"
-repository="https://github.com/g0v/tw-rental-house-data/tree/master/scrapy_twrh"
+repository = "https://github.com/g0v/tw-rental-house-data/tree/master/scrapy-tw-rental-house"
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
## Why
<img width="191" alt="image" src="https://github.com/user-attachments/assets/f6354200-d919-4f29-8146-b9df8d3a0228">
Project links on PyPI is wrong