### PR TITLE
fix: reduce Playwright memory leak and fix house ID parsing

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,24 @@
+Create a git commit for all uncommitted changes using a semantic commit message.
+
+Steps:
+1. Run `git branch --show-current` to get the current branch name.
+   - If the branch is `main`, STOP immediately and warn the user: "Cannot commit directly to main. Please switch to a feature branch first (e.g. git checkout -b feat/your-feature)." Do NOT proceed.
+2. Run `git diff --cached` to check what has been staged.
+   - If nothing is staged, STOP immediately and warn the user: "Nothing is staged. Please use `git add` to stage the changes you want to commit first." Do NOT proceed. Do NOT run `git add` yourself.
+3. Run `git diff` to also understand unstaged changes for context (but do NOT stage them).
+4. Run `git log --oneline -5` to understand the recent commit style of this repo
+5. Analyze staged changes and determine the appropriate semantic commit type:
+   - `feat`: new feature
+   - `fix`: bug fix
+   - `docs`: documentation only
+   - `chore`: build, config, tooling, dependencies
+   - `refactor`: code restructuring without behavior change
+   - `style`: formatting, whitespace
+   - `test`: adding or updating tests
+6. Write a concise semantic commit message in the format: `type(optional-scope): short description`
+   - Keep the subject line under 72 characters
+   - Focus on "why", not just "what"
+8. Commit using a heredoc to preserve formatting
+9. Show the resulting commit with `git log --oneline -1`
+
+Do NOT push. Do NOT amend existing commits.

--- a/.claude/commands/publish-scrapy-twrh.md
+++ b/.claude/commands/publish-scrapy-twrh.md
@@ -1,0 +1,28 @@
+Publish scrapy-tw-rental-house to PyPI and update downstream dependencies.
+
+Steps:
+
+1. Ask the user to confirm:
+   - The new version number (show the current version from `scrapy-tw-rental-house/pyproject.toml`)
+   - Release notes / changelog summary
+
+2. Bump the version in `scrapy-tw-rental-house/pyproject.toml`.
+
+3. Build and publish:
+   ```bash
+   cd scrapy-tw-rental-house
+   poetry build
+   poetry publish
+   ```
+
+4. Update the `scrapy-tw-rental-house` dependency version in `twrh-dataset/pyproject.toml`.
+
+5. Re-install in twrh-dataset:
+   ```bash
+   cd twrh-dataset
+   poetry update scrapy-tw-rental-house
+   ```
+
+6. Inform the user of the completed publish and downstream update.
+
+Do NOT commit or push automatically. Let the user decide when to stage and commit.

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -1,0 +1,41 @@
+Push the current branch to origin and create a GitLab Merge Request using `glab`.
+
+Steps:
+
+1. Run `git branch --show-current` to get the current branch name.
+   - If the branch is `main`, STOP and warn: "Cannot push main directly. Switch to a feature branch first." Do NOT proceed.
+
+2. Run `git status` to confirm there are no uncommitted changes. If there are, warn the user and stop — they should commit first.
+
+3. Push to origin:
+   ```
+   git push -u origin <branch>
+   ```
+
+4. Determine the merge request content from the branch's commit log:
+   - Run `git log main..<branch> --oneline` to list all commits on this branch.
+   - Run `git log main..<branch> --format="%s%n%b"` to get subjects and bodies.
+   - Derive an MR **title**: a concise one-line summary (≤72 chars) of what the branch delivers as a whole.
+   - Derive an MR **description** in this format:
+     ```
+     ## Summary
+     - <bullet per logical change, distilled from commit log>
+
+     ## Commits
+     - <each commit oneline>
+     ```
+
+5. Create the MR with `glab`:
+   ```
+   glab mr create \
+     --title "<mr title>" \
+     --description "<mr description>" \
+     --target-branch main \
+     --remove-source-branch \
+     --yes
+   ```
+   Use a heredoc or `$'...'` quoting to safely pass multi-line description.
+
+6. Print the MR URL returned by `glab`.
+
+Do NOT merge the MR. Do NOT force-push.

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -1,9 +1,9 @@
-Push the current branch to origin and create a GitLab Merge Request using `glab`.
+Push the current branch to origin and create a GitHub Pull Request using `gh`.
 
 Steps:
 
 1. Run `git branch --show-current` to get the current branch name.
-   - If the branch is `main`, STOP and warn: "Cannot push main directly. Switch to a feature branch first." Do NOT proceed.
+   - If the branch is `master`, STOP and warn: "Cannot push master directly. Switch to a feature branch first." Do NOT proceed.
 
 2. Run `git status` to confirm there are no uncommitted changes. If there are, warn the user and stop — they should commit first.
 
@@ -12,11 +12,11 @@ Steps:
    git push -u origin <branch>
    ```
 
-4. Determine the merge request content from the branch's commit log:
-   - Run `git log main..<branch> --oneline` to list all commits on this branch.
-   - Run `git log main..<branch> --format="%s%n%b"` to get subjects and bodies.
-   - Derive an MR **title**: a concise one-line summary (≤72 chars) of what the branch delivers as a whole.
-   - Derive an MR **description** in this format:
+4. Determine the pull request content from the branch's commit log:
+   - Run `git log master..<branch> --oneline` to list all commits on this branch.
+   - Run `git log master..<branch> --format="%s%n%b"` to get subjects and bodies.
+   - Derive a PR **title**: a concise one-line summary (≤72 chars) of what the branch delivers as a whole.
+   - Derive a PR **description** in this format:
      ```
      ## Summary
      - <bullet per logical change, distilled from commit log>
@@ -25,17 +25,17 @@ Steps:
      - <each commit oneline>
      ```
 
-5. Create the MR with `glab`:
+5. Create the PR with `gh`:
    ```
-   glab mr create \
-     --title "<mr title>" \
-     --description "<mr description>" \
-     --target-branch main \
-     --remove-source-branch \
-     --yes
+   gh pr create \
+     --title "<pr title>" \
+     --body "$(cat <<'EOF'
+   <pr description>
+   EOF
+   )" \
+     --base master
    ```
-   Use a heredoc or `$'...'` quoting to safely pass multi-line description.
 
-6. Print the MR URL returned by `glab`.
+6. Print the PR URL returned by `gh`.
 
-Do NOT merge the MR. Do NOT force-push.
+Do NOT merge the PR. Do NOT force-push.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git commit*)",
+      "Bash(git merge*)",
+      "Bash(git checkout*)",
+      "Bash(git branch*)",
+      "Bash(glab mr*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Open Taiwan rental housing data (開放台灣民間租屋資料) - a monorepo that collects, processes, and publishes rental listing data from Taiwanese rental websites (primarily 591.com.tw). Licensed CC0 for open data.
+
+Language: project docs and comments are primarily in Traditional Chinese (zh-TW).
+
+## Repository Structure
+
+| Package | Purpose | Stack |
+|---|---|---|
+| `scrapy-tw-rental-house/` | Core Scrapy spider package (published to PyPI) | Python 3.10+, Poetry, Scrapy, Playwright, PaddleOCR |
+| `twrh-dataset/` | Full data pipeline: crawling, storage, export | Python 3.10+, Poetry, Django 5, PostgreSQL/GeoDjango |
+| `scrapy-twrh-example/` | Example spiders showing package usage | Python, Poetry |
+| `ui/` | Public website (rentalhouse.g0v.ddio.io) | Nuxt.js 2, Vue 2, Buefy |
+| `csv-aggregator/` | CSV merge/dedup utility | Bash, Clickhouse local |
+
+## Common Commands
+
+### scrapy-tw-rental-house (core spider package)
+```bash
+cd scrapy-tw-rental-house
+poetry install
+poetry run playwright install chromium
+```
+
+### twrh-dataset (main data pipeline)
+```bash
+cd twrh-dataset
+poetry install
+
+# Run full crawl pipeline (list -> detail -> sync -> stats -> export)
+./go.sh [--append] [--start-early]
+
+# Individual spiders
+poetry run scrapy crawl list591 -L INFO
+poetry run scrapy crawl detail591 -L INFO
+
+# Django management commands
+poetry run python django/manage.py syncstateful -ts    # Sync time-series
+poetry run python django/manage.py statscheck          # Generate stats, notify Slack
+poetry run python django/manage.py export -p           # Export CSV/JSON datasets
+poetry run python django/manage.py invalidate          # Mark missing houses
+poetry run python django/manage.py archivehistory      # Archive old snapshots
+```
+
+### ui (frontend)
+```bash
+cd ui
+npm install
+npm run dev        # Dev server with hot reload
+npm run generate   # Static site generation (for gh-pages deploy)
+npm run lint       # ESLint
+```
+
+## Dev/Test Workflow for scrapy-tw-rental-house
+
+When a change touches `scrapy-tw-rental-house/`:
+
+### 1. Development & Verification
+
+1. Make changes in `scrapy-tw-rental-house/`
+2. Smoke-test via the trial spider:
+   ```bash
+   cd scrapy-tw-rental-house/trial
+   ./go.sh
+   ```
+3. Test via `scrapy-twrh-example` (uses local path dep, picks up changes automatically):
+   ```bash
+   cd scrapy-twrh-example
+   poetry install
+   poetry run scrapy crawl singleCity -a city="金門縣" -L INFO   # small dataset
+   poetry run scrapy crawl singleCity -a city="花蓮縣" -L INFO   # larger dataset
+   ```
+4. Review console output for errors/warnings.
+
+
+## Architecture
+
+### Data Flow
+1. `list591_spider` crawls rental listings sorted by post date
+2. `detail591_spider` crawls individual listing details
+3. `CrawlerPipeline` stores items via Django ORM into PostgreSQL
+4. `syncstateful` updates time-series aggregations
+5. `statscheck` sends Slack notifications
+6. `export` generates CSV/JSON dataset files
+7. `csv-aggregator` merges monthly ZIPs into quarterly/yearly
+
+### Spider Design (scrapy-tw-rental-house)
+- `RentalSpider` is the abstract base class; concrete spiders override `default_handler`, `start_list`, `parse_list`, `parse_detail`
+- Two item types: `GenericHouseItem` (normalized schema) and `RawHouseItem` (raw preservation)
+- Anti-crawler: Playwright for JS rendering, PaddleOCR for CAPTCHA bypass, OCR results cached by image hash
+- Region data: `scrapy_twrh/tw_regions.json` defines top/sub regions
+
+### Django Models (twrh-dataset)
+- `House` - current rental listings, deduplicated by (vendor, vendor_house_id)
+- `HouseTS` - time-series snapshots (year/month/day/hour partitioned)
+- `HouseEtc` - raw/detail data blob storage
+- Uses GeoDjango `PointField` (WGS84/SRID 4326) for coordinates
+- Deal status is preserved: once marked DEAL, pipeline won't overwrite
+
+### Key Configuration
+- Scrapy: `AUTOTHROTTLE_ENABLED=True`, `DOWNLOAD_DELAY=1`, `COOKIES_ENABLED=False`, `ROBOTSTXT_OBEY=True`
+- Django local settings: `twrh-dataset/django/backend/settings_local.py` (not committed)
+- Sentry and Slack integrations configured via settings
+
+## Git Workflow
+- Never run `git add` automatically. Let the user decide what to stage.
+- When committing, if nothing is staged, warn the user instead of proceeding.
+
+## CI/CD
+- GitHub Actions deploys `ui/` to gh-pages on push to master
+- PR checks run ESLint on `ui/`
+- Dependabot monitors npm and GitHub Actions dependencies

--- a/scrapy-tw-rental-house/scrapy_twrh/spiders/rental591/ocr_utils.py
+++ b/scrapy-tw-rental-house/scrapy_twrh/spiders/rental591/ocr_utils.py
@@ -7,6 +7,7 @@ from paddleocr import PaddleOCR
 from paddleocr.ppocr.utils.logging import get_logger
 import hashlib
 import json
+from collections import OrderedDict
 from pathlib import Path
 from scrapy.utils.project import get_project_settings
 
@@ -31,8 +32,24 @@ CACHE_DIR = Path(CACHE_DIR_PATH)
 if CACHE_ENABLED:
     CACHE_DIR.mkdir(exist_ok=True, parents=True)
 
-# In-memory cache for faster access
-_ocr_cache = {}
+# In-memory LRU cache for faster access
+class _LRUCache(OrderedDict):
+    def __init__(self, maxsize=10000):
+        super().__init__()
+        self.maxsize = maxsize
+    def __setitem__(self, key, value):
+        if key in self:
+            self.move_to_end(key)
+        super().__setitem__(key, value)
+        if len(self) > self.maxsize:
+            self.pop(next(iter(self)))
+    def __contains__(self, key):
+        if super().__contains__(key):
+            self.move_to_end(key)
+            return True
+        return False
+
+_ocr_cache = _LRUCache(maxsize=10000)
 
 def save_base64_image_to_file(base64_str, output_path=None):
     """
@@ -114,9 +131,6 @@ def ocr_via_paddle(image, char_whitelist='0123456789F/.,', chop_right=0, use_zh=
     if chop_right > 0:
         height, width = image.shape[:2]
         image = image[:, :width - chop_right]
-
-    # Save preprocessed image for debugging
-    cv2.imwrite('preprocessed_paddle.png', image)
 
     # Run PaddleOCR with detection and classification disabled
     # This treats the image as a single text line for simple digit recognition

--- a/scrapy-tw-rental-house/scrapy_twrh/spiders/rental591/playwright_utils.py
+++ b/scrapy-tw-rental-house/scrapy_twrh/spiders/rental591/playwright_utils.py
@@ -27,9 +27,6 @@ class PlaywrightUtils:
         if self.js_cache_enabled:
             self.js_cache_dir.mkdir(exist_ok=True, parents=True)
             logger.info('JS caching enabled, using directory: %s', self.js_cache_dir)
-        
-        # In-memory cache for faster access
-        self._js_cache = {}
 
     def _get_cache_path(self, url):
         """Get cached JS file path with sharding for better filesystem performance"""
@@ -59,25 +56,17 @@ class PlaywrightUtils:
             elif resource_type == 'script' and self.js_cache_enabled:
                 try:
                     cache_path = self._get_cache_path(url)
-                    
-                    # Check memory cache first
-                    if url in self._js_cache:
-                        await route.fulfill(body=self._js_cache[url], content_type='application/javascript')
-                        return
-                    
+
                     # Check file cache
                     if cache_path.exists():
                         js_content = cache_path.read_bytes()
-                        self._js_cache[url] = js_content
                         await route.fulfill(body=js_content, content_type='application/javascript')
                         return
-                    
-                    # Cache miss - fetch and cache
+
+                    # Cache miss - fetch and cache to disk only
                     response = await route.fetch()
                     if response.ok:
                         js_content = await response.body()
-                        # Cache in memory and on disk
-                        self._js_cache[url] = js_content
                         cache_path.write_bytes(js_content)
                         await route.fulfill(body=js_content, content_type='application/javascript')
                         return

--- a/scrapy-twrh-example/go.sh
+++ b/scrapy-twrh-example/go.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Ensure scrapy-tw-rental-house is up-to-date with local source
+poetry update scrapy-tw-rental-house
+
+echo '===== 591 ====='
+poetry run scrapy crawl singleCity -a city=花蓮縣 -L INFO
+

--- a/scrapy-twrh-example/poetry.lock
+++ b/scrapy-twrh-example/poetry.lock
@@ -2093,7 +2093,7 @@ typing = "*"
 
 [[package]]
 name = "scrapy-tw-rental-house"
-version = "2.1.4"
+version = "2.1.7"
 description = "Scrapy spider for TW Rental House"
 optional = false
 python-versions = "^3.10"

--- a/twrh-dataset/crawler/spiders/detail591_spider.py
+++ b/twrh-dataset/crawler/spiders/detail591_spider.py
@@ -9,7 +9,7 @@ from .persist_queue import PersistQueue
 class Detail591Spider(Rental591Spider):
     name = "detail591"
 
-    def __init__(self, append=False, start_early=False, **kwargs):
+    def __init__(self, append=False, start_early=False, batch_size=0, **kwargs):
         super().__init__(
             start_list=self.start_detail_requests,
             **kwargs
@@ -17,7 +17,8 @@ class Detail591Spider(Rental591Spider):
 
         self.append = append == 'True' or append == True
         self.start_early = start_early == 'True' or start_early == True
-        
+        self.batch_size = int(batch_size)
+
         self.persist_queue = PersistQueue(
             vendor='591 租屋網',
             is_list=False,
@@ -25,7 +26,8 @@ class Detail591Spider(Rental591Spider):
             seed_parser=self.parse_seed,
             generate_request_args=self.gen_detail_request_args,
             parse_response=self.parse_detail_and_done,
-            start_early=self.start_early
+            start_early=self.start_early,
+            batch_size=self.batch_size
         )
     
     @classmethod

--- a/twrh-dataset/crawler/spiders/persist_queue.py
+++ b/twrh-dataset/crawler/spiders/persist_queue.py
@@ -25,6 +25,7 @@ class PersistQueue(object):
         parse_response,
         log_interval=60,
         start_early=False,
+        batch_size=0,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -66,6 +67,7 @@ class PersistQueue(object):
         else:
             self.request_type = RequestType.DETAIL
 
+        self.batch_size = batch_size
         self.ts = {
             'y': y,
             'm': m,
@@ -104,6 +106,10 @@ class PersistQueue(object):
         total = self.get_total_count()
         self.progress_tracker.set_total(total)
         return total
+
+    def is_batch_complete(self):
+        """Check if the batch limit has been reached."""
+        return self.batch_size > 0 and self.progress_tracker.completed >= self.batch_size
 
     def has_record(self):
         today_houses = HouseTS.objects.filter(
@@ -220,6 +226,14 @@ class PersistQueue(object):
             traceback.print_exc()
 
         self.n_live_spider -= 1
+
+        if self.is_batch_complete():
+            self.logger.info(
+                'Batch limit reached (%d items), stopping to release memory...',
+                self.batch_size
+            )
+            return
+
         # quick fix for concurrency issue
         mercy = 10
         while True:

--- a/twrh-dataset/go.sh
+++ b/twrh-dataset/go.sh
@@ -31,8 +31,18 @@ poetry run scrapy crawl list591 -L INFO $APPEND_FLAG $START_EARLY_FLAG
 mv scrapy.log ../logs/$now.list.log
 
 echo '===== DETAIL ====='
-poetry run scrapy crawl detail591 -L INFO $APPEND_FLAG $START_EARLY_FLAG
-mv scrapy.log ../logs/$now.detail.log
+DETAIL_BATCH=1
+DETAIL_BATCH_SIZE=2000
+while true; do
+    echo "--- detail batch $DETAIL_BATCH ---"
+    poetry run scrapy crawl detail591 -L INFO $APPEND_FLAG $START_EARLY_FLAG -a batch_size=$DETAIL_BATCH_SIZE
+    mv scrapy.log ../logs/$now.detail.$DETAIL_BATCH.log
+    # Exit loop when spider finishes before hitting the batch limit (all done)
+    if ! grep -q 'Batch limit reached' ../logs/$now.detail.$DETAIL_BATCH.log; then
+        break
+    fi
+    DETAIL_BATCH=$((DETAIL_BATCH + 1))
+done
 
 echo '===== STATEFUL UPDATE ====='
 poetry run python ./django/manage.py syncstateful -ts

--- a/twrh-dataset/tools/monitor_python_memory.sh
+++ b/twrh-dataset/tools/monitor_python_memory.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Monitor memory usage for Python processes periodically
+# Monitor memory usage for Python and Playwright-related processes periodically
 
 # Configuration
 LOG_FILE="python_memory_usage.log"
@@ -10,7 +10,7 @@ if [ ! -f "$LOG_FILE" ]; then
     echo "Timestamp,PID,Process Name,%CPU,%MEM,RSS(KB),VSZ(KB),Command" > "$LOG_FILE"
 fi
 
-echo "Starting Python process memory monitoring..."
+echo "Starting Python & Playwright process memory monitoring..."
 echo "Logging to: $LOG_FILE"
 echo "Interval: ${INTERVAL}s"
 echo "Press Ctrl+C to stop"
@@ -18,9 +18,12 @@ echo "Press Ctrl+C to stop"
 # Function to log memory usage
 log_memory() {
     local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-    
-    # Get all Python processes
-    ps aux | grep -E '[p]ython' | while read -r line; do
+
+    # Get all Python and Playwright-related processes
+    # - [p]ython: Python processes (scrapy, django, etc.)
+    # - [c]hromium: Chromium browser processes spawned by Playwright
+    # - [c]hrome: Chrome browser processes spawned by Playwright
+    ps aux | grep -E '[p]ython|[c]hromium|[c]hrome' | while read -r line; do
         # Parse ps output
         pid=$(echo "$line" | awk '{print $2}')
         cpu=$(echo "$line" | awk '{print $3}')
@@ -29,7 +32,7 @@ log_memory() {
         rss=$(echo "$line" | awk '{print $6}')
         cmd=$(echo "$line" | awk '{for(i=11;i<=NF;i++) printf $i" "; print ""}')
         process_name=$(echo "$cmd" | awk '{print $1}')
-        
+
         # Append to log file
         echo "$timestamp,$pid,$process_name,$cpu,$mem,$rss,$vsz,$cmd" >> "$LOG_FILE"
     done
@@ -43,4 +46,3 @@ while true; do
     log_memory
     sleep "$INTERVAL"
 done
-write to 


### PR DESCRIPTION
## Summary
- Reduce memory growth during long-running detail spider crawls (LRU cache, remove unbounded JS cache, cap browser contexts/tabs)
- Batch-restart detail spider process to reclaim Playwright memory between rounds
- Fix house ID parsing bug where query params (e.g. `?is_ai_video=1&ai_title_id=...`) were not stripped from 591 URLs
- Add Claude Code project config and custom commands

## Commits
- bf38ce9 chore: update push cmd for gh
- 14ebdb1 chore(scrapy-twrh-example): update scrapy-tw-rental-house to v2.1.7
- d6f8ed1 fix: batch-restart detail spider to prevent Playwright memory leak
- a4982c2 fix: reduce memory growth during long-running detail spider crawls
- 70819c2 chore: add Claude Code project config and custom commands