### PR TITLE
fix(scrapy-twrh): split nuxt argument list by top level comma only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,16 @@ Needs `clickhouse local` on PATH.
 
 ## Testing
 
-There is **no automated test suite** — `django/*/tests.py` are empty stubs and no pytest/unittest
-config exists. Verification is manual, by running spiders against small real datasets.
+`scrapy-tw-rental-house` has an offline pytest suite (`scrapy-tw-rental-house/tests`):
+
+```bash
+cd scrapy-tw-rental-house
+poetry install --with dev
+poetry run pytest
+```
+
+`twrh-dataset` has none — `django/*/tests.py` are empty stubs, and verification there is manual,
+by running spiders against small real datasets.
 
 ### Dev/Test Workflow for scrapy-tw-rental-house
 

--- a/scrapy-tw-rental-house/.gitignore
+++ b/scrapy-tw-rental-house/.gitignore
@@ -7,3 +7,4 @@ dist
 trial
 survey-output
 ocr_cache
+.pytest_cache

--- a/scrapy-tw-rental-house/README.md
+++ b/scrapy-tw-rental-house/README.md
@@ -70,6 +70,13 @@ BROWSER_SKIP_DOMAIN = [
 ]
 ```
 
+### Tests
+
+```bash
+poetry install --with dev
+poetry run pytest
+```
+
 ## Basic Usage
 
 This package currently support [591](http://rent.591.com.tw/). Each rental house website is a Scrapy Spider class. You can either crawl entire website using default setting , which will take couple days, or customize the behaviour base on your need.

--- a/scrapy-tw-rental-house/pyproject.toml
+++ b/scrapy-tw-rental-house/pyproject.toml
@@ -25,6 +25,12 @@ paddleocr = "^2.10.0"
 [tool.poetry.scripts]
 twrh = "scrapy_twrh.cli.main:main"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/scrapy-tw-rental-house/scrapy_twrh/spiders/rental591/util.py
+++ b/scrapy-tw-rental-house/scrapy_twrh/spiders/rental591/util.py
@@ -1,3 +1,4 @@
+import json
 import re
 from collections import namedtuple
 from scrapy.http import Response
@@ -108,6 +109,64 @@ def from_zh_number(zh_number):
         raise Exception('ZH number {} not defined.'.format(zh_number))
 
 
+def split_js_arguments(arg_string):
+    '''
+    split a JS argument list by top level comma
+    'a,"b,c",[1,2]' -> ['a', '"b,c"', '[1,2]']
+    '''
+    args = []
+    token = []
+    depth = 0
+    quote = None
+    is_escaped = False
+
+    for char in arg_string:
+        if quote:
+            token.append(char)
+            if is_escaped:
+                is_escaped = False
+            elif char == '\\':
+                is_escaped = True
+            elif char == quote:
+                quote = None
+        elif char in '"\'':
+            quote = char
+            token.append(char)
+        elif char in '[{(':
+            depth += 1
+            token.append(char)
+        elif char in ']})':
+            depth -= 1
+            token.append(char)
+        elif char == ',' and depth == 0:
+            args.append(''.join(token))
+            token = []
+        else:
+            token.append(char)
+
+    args.append(''.join(token))
+
+    return args
+
+def unquote_js_string(raw_value):
+    '''
+    '"元\\u002F月"' -> '元/月', '12' -> '12'
+    '''
+    value = raw_value.strip()
+
+    if len(value) < 2 or value[0] != value[-1] or value[0] not in '"\'':
+        return value
+
+    body = value[1:-1]
+    if value[0] == "'":
+        # json only knows double quoted string
+        body = body.replace('\\\'', '\'').replace('"', '\\"')
+
+    try:
+        return json.loads(f'"{body}"')
+    except ValueError:
+        return body
+
 class SimpleNuxtInitParser:
     '''
     A simple parser to read nuxt init script, without using AST
@@ -137,26 +196,18 @@ class SimpleNuxtInitParser:
         get values of the function call using regex, and store them in a list
         match: }(a, b, c, ...)
         '''
-        matches = re.search(r'}\((.+)\)\)', self.script)
+        matches = re.search(r'}\((.+)\)\)', self.script, re.DOTALL)
         if not matches:
             return []
 
-        value_str = matches.group(1)
-        # dirty hack 0, remove font-family as there is a comma in the string
-        value_str = re.sub(r'font-family:[^;]+;', '', value_str)
-
-        # dirty hack 1, remove comma from "12,345" XD
-        value_str = re.sub(r'"(\d+),(\d+)"', r'\1\2', value_str)
-        # dirty hack 2, we won't need "市中心,拎包入住,含車位" for now.
-        # we have to remove the comma in the string
-        value_str = re.sub(r'"(([^\u0000-\u007F]|\\)[^",]*),[^"]+"', r'\1', value_str)
-        ret = []
-        for raw_value in value_str.split(','):
-            # remove leading and trailing double quotes
-            value = raw_value.strip(' "')
-            ret.append(value)
-
-        return ret
+        # split in a quote aware way, so that a value holding a comma, say
+        # "12,345" or "市中心,拎包入住,含車位", stays in one piece. Splitting
+        # those apart shifts all the following values by one, which silently
+        # maps every argument to a wrong value.
+        return [
+            unquote_js_string(raw_value)
+            for raw_value in split_js_arguments(matches.group(1))
+        ]
 
     def compose_arg_dict(self):
         '''

--- a/scrapy-tw-rental-house/tests/test_nuxt_parser.py
+++ b/scrapy-tw-rental-house/tests/test_nuxt_parser.py
@@ -1,0 +1,80 @@
+from scrapy_twrh.spiders.rental591.util import (
+    SimpleNuxtInitParser,
+    split_js_arguments,
+    unquote_js_string,
+)
+
+def test_split_arguments_by_top_level_comma():
+    assert split_js_arguments('a,b,1') == ['a', 'b', '1']
+
+def test_keep_comma_inside_string():
+    assert split_js_arguments('a,"12,345",b') == ['a', '"12,345"', 'b']
+    assert split_js_arguments('"市中心,拎包入住,含車位",a') == [
+        '"市中心,拎包入住,含車位"',
+        'a'
+    ]
+
+def test_keep_comma_inside_bracket():
+    assert split_js_arguments('a,[1,2],{b:1,c:2}') == ['a', '[1,2]', '{b:1,c:2}']
+
+def test_keep_escaped_quote_inside_string():
+    assert split_js_arguments(r'"say \"hi\", now",a') == [r'"say \"hi\", now"', 'a']
+
+def test_unquote_string():
+    assert unquote_js_string('"元\\u002F月"') == '元/月'
+    assert unquote_js_string("'a'") == 'a'
+    assert unquote_js_string(' 12 ') == '12'
+    assert unquote_js_string('void 0') == 'void 0'
+
+def test_map_arguments_to_values():
+    parser = SimpleNuxtInitParser(
+        'window.__NUXT__=(function(a,b,c){return {x:a}}("first","second","third"))'
+    )
+
+    assert parser.dict == {'a': 'first', 'b': 'second', 'c': 'third'}
+
+def test_map_arguments_to_values_holding_comma():
+    '''
+    the bug this test guards: splitting the argument list by every comma
+    pushes all the following values one slot forward, so that every argument
+    reads a value of its neighbor
+    '''
+    parser = SimpleNuxtInitParser(
+        'window.__NUXT__=(function(a,b,c){return {x:a}}'
+        '("12,345","市中心,拎包入住,含車位","third"))'
+    )
+
+    assert parser.dict == {
+        'a': '12,345',
+        'b': '市中心,拎包入住,含車位',
+        'c': 'third'
+    }
+
+def test_read_component_arguments():
+    parser = SimpleNuxtInitParser(
+        'window.__NUXT__=(function(a,b,c){'
+        'return {positionRound:{address:a,lat:b,lng:c}}'
+        '}("前鎮區中山二路","22.6100707","120.3052884"))'
+    )
+
+    assert parser.get_component_arg_list(['address', 'lat', 'lng']) == [{
+        'address': '前鎮區中山二路',
+        'lat': '22.6100707',
+        'lng': '120.3052884'
+    }]
+
+def test_keep_comma_inside_inline_style():
+    '''
+    the 屋況介紹 of a house carries inline style, say the house 21788398 whose
+    description holds `rgb(20, 106, 153)`. Both the commas of the color and
+    the ones of the sentences live in the same value.
+    '''
+    parser = SimpleNuxtInitParser(
+        'window.__NUXT__=(function(a,b){return {x:a}}'
+        '("<p style=\\"color: rgb(20, 106, 153)\\">近捷運,近商圈</p>","22.6100707"))'
+    )
+
+    assert parser.dict == {
+        'a': '<p style="color: rgb(20, 106, 153)">近捷運,近商圈</p>',
+        'b': '22.6100707'
+    }


### PR DESCRIPTION
SimpleNuxtInitParser cut the argument list of the nuxt init script by every comma, including the ones inside a string. A value holding a comma was therefore counted as two or more values, which pushed all the following values one slot forward, and made every argument read a value of its neighbor:

    address: 'room', lat: '左營區新庄仔路712巷', lng: '22.6682835'

Real triggers: the inline style of 屋況介紹, say `rgb(20, 106, 153)` of house 21788398, and values like "12,345" or "市中心,拎包入住,含車位".

Split in a quote aware way instead, and decode the escapes of the value we take out, so that "元/月" reads as 元/月.

Since 經緯度 is the only data the parser reads from the nuxt script, this also decides whether rough_coordinate lands on the right house.

Brings pytest to the package to host the test, tests live in scrapy-tw-rental-house/tests.