### PR TITLE
fix(scrapy-twrh): drop the default scrapy user agent for 591

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,16 @@ Needs `clickhouse local` on PATH.
 
 ## Testing
 
-There is **no automated test suite** — `django/*/tests.py` are empty stubs and no pytest/unittest
-config exists. Verification is manual, by running spiders against small real datasets.
+`scrapy-tw-rental-house` has an offline pytest suite (`scrapy-tw-rental-house/tests`):
+
+```bash
+cd scrapy-tw-rental-house
+poetry install --with dev
+poetry run pytest
+```
+
+`twrh-dataset` has none — `django/*/tests.py` are empty stubs, and verification there is manual,
+by running spiders against small real datasets.
 
 ### Dev/Test Workflow for scrapy-tw-rental-house
 

--- a/scrapy-tw-rental-house/.gitignore
+++ b/scrapy-tw-rental-house/.gitignore
@@ -7,3 +7,4 @@ dist
 trial
 survey-output
 ocr_cache
+.pytest_cache

--- a/scrapy-tw-rental-house/README.md
+++ b/scrapy-tw-rental-house/README.md
@@ -37,6 +37,9 @@ get access to browser developer tool on browsing 591, and copy the setting to se
 BROWSER_INIT_SCRIPT = 'console.log("This command enable Playwright")'
 ```
 
+591 also replies 403 to the default scrapy user agent, so this package sets
+`USER_AGENT` to `None` unless the project configures its own.
+
 ### Configure OCR cache
 
 As OCR is a time consuming process, we provide a cache mechanism to store OCR result. When OCR cache is enabled, before performing OCR on an image, the crawler will check if the image hash exists in the cache. If it exists, the cached result will be used instead of performing OCR again. OCR cache is enabled by default.
@@ -68,6 +71,13 @@ BROWSER_JS_CACHE_DIR = 'path/to/cache' # default to js_cache
 BROWSER_SKIP_DOMAIN = [
     'https://the.unnecessary.domain',
 ]
+```
+
+### Tests
+
+```bash
+poetry install --with dev
+poetry run pytest
 ```
 
 ## Basic Usage

--- a/scrapy-tw-rental-house/pyproject.toml
+++ b/scrapy-tw-rental-house/pyproject.toml
@@ -25,6 +25,12 @@ paddleocr = "^2.10.0"
 [tool.poetry.scripts]
 twrh = "scrapy_twrh.cli.main:main"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/scrapy-tw-rental-house/scrapy_twrh/spiders/rental591/rental591_spider.py
+++ b/scrapy-tw-rental-house/scrapy_twrh/spiders/rental591/rental591_spider.py
@@ -40,3 +40,10 @@ class Rental591Spider(ListMixin, DetailMixin):
         # for backward compatibility
         settings.set('TWISTED_REACTOR', 'twisted.internet.asyncioreactor.AsyncioSelectorReactor', priority='spider')
 
+        # 591 replies 403 to the default scrapy user agent, while it serves
+        # requests without user agent just fine. Keep the one set by the
+        # project, if there is any.
+        user_agent = settings.get('USER_AGENT')
+        if not user_agent or user_agent.startswith('Scrapy/'):
+            settings.set('USER_AGENT', None, priority='spider')
+

--- a/scrapy-tw-rental-house/tests/test_user_agent.py
+++ b/scrapy-tw-rental-house/tests/test_user_agent.py
@@ -1,0 +1,20 @@
+from scrapy.settings import Settings
+
+from scrapy_twrh.spiders.rental591 import Rental591Spider
+
+def update_settings(**custom):
+    settings = Settings()
+    for name, value in custom.items():
+        settings.set(name, value, priority='project')
+    Rental591Spider.update_settings(settings)
+    return settings
+
+def test_drop_default_scrapy_user_agent():
+    # 591 replies 403 to it, while it serves requests without one just fine
+    assert update_settings().get('USER_AGENT') is None
+
+def test_keep_user_agent_of_the_project():
+    assert update_settings(USER_AGENT='my-crawler').get('USER_AGENT') == 'my-crawler'
+
+def test_drop_empty_user_agent():
+    assert update_settings(USER_AGENT='').get('USER_AGENT') is None


### PR DESCRIPTION
591 replies 403 to `Scrapy/2.x (+https://scrapy.org)`, while it serves requests carrying no user agent at all just fine:

    UA='Scrapy/2.11 (+https://scrapy.org)' -> 403
    UA='python-requests/2.31'              -> 403
    UA=<none>                              -> 200

Set USER_AGENT to None when the project keeps the scrapy default, and keep the user agent of the project untouched when it sets its own.

The pytest scaffolding is here only to host the test, and is written to be identical to the one of the nuxt comma fix, so that the two merge in either order.