### PR TITLE
fix(ui): render about-data-set TOC on first load instead of after scroll

### DIFF
--- a/ui/pages/about-data-set/0.0.vue
+++ b/ui/pages/about-data-set/0.0.vue
@@ -9,7 +9,7 @@
         nuxt-link(to="/about-data-set") 新版資料集
       h1 關於資料集
       about-data-brief
-      vue-markdown(:breaks="false", :html="true", :toc="true", tocId="data-set-toc").
+      vue-markdown(:breaks="false", :html="true", :toc="true", tocId="data-set-toc", @toc-rendered="onTocRendered").
         ## 版本資訊
         1. 版本： 0.0
         2. 發行日期： 2018/06/06
@@ -211,6 +211,20 @@ export default {
   methods: {
     visibilityChanged (isVisible) {
       this.isHeaderVisible = isVisible
+    },
+    // vue-markdown's own toc-and-anchor plugin writes the TOC into #data-set-toc via
+    // document.getElementById() *during* its render(), before that element has been
+    // attached to the document on first mount — so the write silently no-ops and the
+    // TOC stays empty until something else forces a re-render (e.g. scrolling toggles
+    // isHeaderVisible above). Re-apply the html here once mounted, when the element is
+    // guaranteed to exist.
+    onTocRendered (tocHtml) {
+      this.$nextTick(() => {
+        const el = document.getElementById('data-set-toc')
+        if (el) {
+          el.innerHTML = tocHtml
+        }
+      })
     }
   }
 }

--- a/ui/pages/about-data-set/0.1.vue
+++ b/ui/pages/about-data-set/0.1.vue
@@ -7,7 +7,7 @@
     article
       h1 關於資料集
       about-data-brief
-      vue-markdown(:breaks="false", :html="true", :toc="true", tocId="data-set-toc").
+      vue-markdown(:breaks="false", :html="true", :toc="true", tocId="data-set-toc", @toc-rendered="onTocRendered").
         ## 版本資訊
         1. 版本： 0.1
         2. 發行日期： 2018/07/31
@@ -246,6 +246,20 @@ export default {
   methods: {
     visibilityChanged (isVisible) {
       this.isHeaderVisible = isVisible
+    },
+    // vue-markdown's own toc-and-anchor plugin writes the TOC into #data-set-toc via
+    // document.getElementById() *during* its render(), before that element has been
+    // attached to the document on first mount — so the write silently no-ops and the
+    // TOC stays empty until something else forces a re-render (e.g. scrolling toggles
+    // isHeaderVisible above). Re-apply the html here once mounted, when the element is
+    // guaranteed to exist.
+    onTocRendered (tocHtml) {
+      this.$nextTick(() => {
+        const el = document.getElementById('data-set-toc')
+        if (el) {
+          el.innerHTML = tocHtml
+        }
+      })
     }
   }
 }

--- a/ui/pages/about-data-set/0.2.vue
+++ b/ui/pages/about-data-set/0.2.vue
@@ -7,7 +7,7 @@
     article
       h1 關於資料集
       about-data-brief
-      vue-markdown(:breaks="false", :html="true", :toc="true", tocId="data-set-toc").
+      vue-markdown(:breaks="false", :html="true", :toc="true", tocId="data-set-toc", @toc-rendered="onTocRendered").
         ## 版本資訊
         1. 版本： 0.2
         2. 發行日期： 2018/08/31
@@ -243,6 +243,20 @@ export default {
   methods: {
     visibilityChanged (isVisible) {
       this.isHeaderVisible = isVisible
+    },
+    // vue-markdown's own toc-and-anchor plugin writes the TOC into #data-set-toc via
+    // document.getElementById() *during* its render(), before that element has been
+    // attached to the document on first mount — so the write silently no-ops and the
+    // TOC stays empty until something else forces a re-render (e.g. scrolling toggles
+    // isHeaderVisible above). Re-apply the html here once mounted, when the element is
+    // guaranteed to exist.
+    onTocRendered (tocHtml) {
+      this.$nextTick(() => {
+        const el = document.getElementById('data-set-toc')
+        if (el) {
+          el.innerHTML = tocHtml
+        }
+      })
     }
   }
 }

--- a/ui/pages/about-data-set/0.3.vue
+++ b/ui/pages/about-data-set/0.3.vue
@@ -7,7 +7,7 @@
     article
       h1 關於資料集
       about-data-brief
-      vue-markdown(:breaks="false", :html="true", :toc="true", tocId="data-set-toc").
+      vue-markdown(:breaks="false", :html="true", :toc="true", tocId="data-set-toc", @toc-rendered="onTocRendered").
         ## 版本資訊
         1. 版本： 0.3
         2. 發行日期： 2023/08/31
@@ -250,6 +250,20 @@ export default {
   methods: {
     visibilityChanged (isVisible) {
       this.isHeaderVisible = isVisible
+    },
+    // vue-markdown's own toc-and-anchor plugin writes the TOC into #data-set-toc via
+    // document.getElementById() *during* its render(), before that element has been
+    // attached to the document on first mount — so the write silently no-ops and the
+    // TOC stays empty until something else forces a re-render (e.g. scrolling toggles
+    // isHeaderVisible above). Re-apply the html here once mounted, when the element is
+    // guaranteed to exist.
+    onTocRendered (tocHtml) {
+      this.$nextTick(() => {
+        const el = document.getElementById('data-set-toc')
+        if (el) {
+          el.innerHTML = tocHtml
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
## Problem

On `/about-data-set` (and the 0.0/0.1/0.2 historical version pages), the TOC
sidebar (`#data-set-toc`) is empty on first load and only appears after you
scroll a bit — matching the repro steps in #2 exactly.

## Root cause

`vue-markdown`'s `toc-and-anchor` plugin writes the generated TOC html into
the target element with a plain `document.getElementById(this.tocId).innerHTML
= tocHtml` call, executed synchronously from inside the component's own
`render()`. On the very first client-side mount, that write runs before
`#data-set-toc` is attached to the live `document`, so it silently no-ops —
nothing throws, the TOC is just empty. The page happens to have a
`v-observe-visibility` scroll listener (`visibilityChanged`) toggling
`isHeaderVisible`, which forces a re-render; on that later pass the container
already exists, so the second write succeeds. That's why scrolling "fixes" it.

Confirmed empirically: with a viewport wide enough to show the desktop TOC,
`#data-set-toc` stays completely empty for 8+ seconds without any scroll, and
only populates immediately after a scroll event.

## Fix

`vue-markdown` already emits a `toc-rendered` event with the same html
regardless of whether its own DOM write succeeded — it's the documented hook
for exactly this situation. Wired it up on all four `about-data-set` version
pages (0.0–0.3, which duplicate the same page structure) and re-apply the
html in a `$nextTick`, by which point the container is guaranteed to be in
the document.

## Verification

- Before the fix: loaded `/about-data-set/0.3` at 1440×900, `#data-set-toc`
  innerHTML stayed empty through 8s of polling with no scroll; a single
  scroll event made it populate.
- After the fix: same page, `#data-set-toc` is populated (1977 chars) within
  500ms of load, no scroll needed, on all four versions (0.0/0.1/0.2/0.3).
- Clicking a TOC link navigates in-page via the URL hash (no new tab opened),
  so this doesn't reintroduce the `target=_blank` issue #3 was originally
  about.
- `npm run lint` (the only automated CI check for `ui/`) passes clean.
- Manually re-checked #3 itself while I was in here: currently `anchorAttributes:
  {target: '_blank'}` is only set on the separate `AboutDataBrief` component,
  and its current markdown source has no internal `#anchor` links, so all 27
  internal anchors on the page — including every TOC link — have no `target`
  attribute today. I didn't find a live repro for #3, so I'm leaving it alone
  rather than "fixing" something that isn't currently broken; happy to be
  pointed at a page where it still reproduces.

Fixes #2
