### PR TITLE
batch 收尾雙修：queue 耗盡不重生成 + 補貨迴圈閘門（4-4 一併）

### DIFF
--- a/twrh-dataset/crawler/spiders/detail591_spider.py
+++ b/twrh-dataset/crawler/spiders/detail591_spider.py
@@ -58,7 +58,14 @@ class Detail591Spider(Rental591Spider):
 
     def start_detail_requests(self):
 
-        if not self.persist_queue.has_request():
+        if not self.persist_queue.has_request() and self.persist_queue.has_run_today():
+            # queue 耗盡 + 今天已跑過 = go.sh batch 重啟時的正常收尾，不是新的一天。
+            # 少了這個判斷，恰好在 batch 邊界耗盡 queue 會觸發下面的全量重生成，
+            # 把全台 open 房源再排一輪（2026-08-26 實測 55,943 筆）。
+            # 若要同日強制重生成（例如 --date 重跑），先刪當日 logs/progress/*.detail.json。
+            self.logger.info(
+                'queue empty and progress file exists — resume with nothing to do')
+        elif not self.persist_queue.has_request():
             # find all opened houses and crawl all of them
             query = House.objects.filter(
                 deal_status = enums.DealStatusType.OPENED

--- a/twrh-dataset/crawler/spiders/persist_queue.py
+++ b/twrh-dataset/crawler/spiders/persist_queue.py
@@ -14,8 +14,6 @@ from crawler import signals as twrh_signals
 from .progress_tracker import ProgressTracker
 
 class PersistQueue(object):
-    queue_length = 30
-    n_live_spider = 0
 
     def __init__(
         self,
@@ -55,6 +53,10 @@ class PersistQueue(object):
             d = models.current_day()
 
         h = models.current_stepped_hour()
+
+        # 4-4：原為 class attribute，靠 `self.x -= 1` 隱式轉 instance 是 footgun
+        self.queue_length = 30
+        self.n_live_spider = 0
 
         self.spider_id = str(uuid.uuid4())
         self.logger = logger
@@ -125,16 +127,29 @@ class PersistQueue(object):
         """
         total = self.get_total_count()
         if self.request_type == RequestType.DETAIL:
-            progress_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'logs', 'progress')
-            os.makedirs(progress_dir, exist_ok=True)
-            progress_file = os.path.join(
-                progress_dir,
-                f"{self.ts['y']}-{self.ts['m']:02d}-{self.ts['d']:02d}.detail.json"
-            )
+            progress_file = self.progress_file_path()
+            os.makedirs(os.path.dirname(progress_file), exist_ok=True)
             self.progress_tracker.init_overall(progress_file, total)
         else:
             self.progress_tracker.set_total(total)
         return total
+
+    def progress_file_path(self):
+        progress_dir = os.path.join(
+            os.path.dirname(__file__), '..', '..', '..', 'logs', 'progress')
+        return os.path.join(
+            progress_dir,
+            f"{self.ts['y']}-{self.ts['m']:02d}-{self.ts['d']:02d}.detail.json"
+        )
+
+    def has_run_today(self):
+        """今天的 detail 是否已經跑過（progress 檔存在）。
+
+        用途：區分「batch 重啟時 queue 恰好耗盡」與「今天還沒生成過種子」——
+        兩者的 has_request() 都是 False，但前者重生成會把全台 open 房源
+        再排一輪（2026-08-26 全量實測踩到）。
+        """
+        return os.path.exists(self.progress_file_path())
 
     def is_batch_complete(self):
         """Check if the batch limit has been reached."""
@@ -271,6 +286,12 @@ class PersistQueue(object):
         # quick fix for concurrency issue
         mercy = 10
         while True:
+            # 這個 generator 每次 yield 都會懸掛，item pipeline 是非同步的，
+            # 所以觸頂前懸掛在迴圈中間的 wrapper 會在觸頂後恢復並繼續認領——
+            # 迴圈內也要檢查，僅靠迴圈前那次檢查擋不住（2026-08-26 batch 13 實測：
+            # 觸頂後仍多爬 2,559 筆，enqueue 全由懸掛中的補貨迴圈餵出）
+            if self.is_batch_complete():
+                break
             next_request = self.next_request()
             if next_request:
                 yield next_request


### PR DESCRIPTION
2026-08-26 全量爬取遺留的最後兩個 batch bug（#219 的續集）：

1. **queue 耗盡的 batch 重啟誤觸全量重生成**：`has_request()` 為 False 有兩種語意（今天還沒生成 vs resume 時恰好收尾完），以「當日 detail progress 檔存在」區分。已對 8/26 的實際空 queue 條件 smoke 驗證：零重生成、正常收工。
2. **batch 額滿的第三條漏網餵食路**：`parser_wrapper` 補貨迴圈是 generator，觸頂前懸掛在迴圈中間的 wrapper 恢復後繼續認領（batch 13 實測觸頂後多爬 2,559 筆、無 redirect/retry/dupe）。迴圈內每輪先檢查 `is_batch_complete()`。順做 dx 4-4：`queue_length` / `n_live_spider` class attr → instance attr。

與 #219 的 start_requests 閘門合併後，batch 額滿的三條餵食路（parser 補貨、start generator、懸掛中的補貨迴圈）全數受控；下次全量即可驗證 batch 每 2000 筆準確重啟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfTMpRp4zRMaym1Lr3jjZm